### PR TITLE
finished adding latient heat source term to Thermal driver

### DIFF
--- a/crevprop/iceblock.py
+++ b/crevprop/iceblock.py
@@ -312,6 +312,7 @@ class IceBlock(Ice):
         # initialize model to time=0
         self.t = 0
         self.dt = dt * pc.SECONDS_IN_DAY
+        self.thermal_freq = thermal_freq
         self.dt_T = self._thermal_timestep(dt, thermal_freq)
 
         # ice block geometry
@@ -360,6 +361,11 @@ class IceBlock(Ice):
 
     #     pass
 
+    def _get_virtualblue(self):
+        virtualblue_left, virtualblue_right = self.temperature.refreezing()
+
+        for num, crev in enumerate(virtualblue_left)
+
     def _init_geometry(self):
         """initialize ice block geometry
 
@@ -399,7 +405,12 @@ class IceBlock(Ice):
             thermal_diffusivity=self.kappa
         )
 
-    def _init_crevfield(self, blunt, include_creep, never_closed, water_compressive):
+    def _init_crevfield(self,
+                        blunt,
+                        include_creep,
+                        never_closed,
+                        water_compressive
+                        ):
         """Initialize CrevasseField for given model geometry"""
         crevasse_field = CrevasseField(self.z,
                                        self.dx,


### PR DESCRIPTION
Adding the latient heat source term to thermal model temperature calculation is complete.

refreezing calculation in thermal model complete. however, at present, blueband/virutalblue/refreezing is being calculated for crevasse depth only, not for entire ice thickness as I think it is in Matlab script. 

**TODO**: change such that virtual blue is being calculated for entire ice thickness (after confirming with Matlab script that this is the case). Updates required to `ThermalModel.refreezing()`.


**DECISION**: Conversion of `virtualblue`, potential possible refreezing rate for timestep, from `ThermalModel` `dz` vertical resolution to `IceBlock` dz resolution and timestep conversion (I.e., divide rate by `IceBlock.thermal_freq` will occur in `IceBlock` method.

Method executes `ThermalModel.refreezing()` on class instance stored within `IceBlock.temperature` which will return (`virtualblue_left`,`virtualblue_right`) both of which are`np.array`s. The method then needs to divide all values in each array by `self.thermal_freq`, then interpolate to ice block's vertical (z) resolution. with something like

```python
virtualblue_left, virtual blue_right = self.temperature.refreezing()

# if .refreezing() is changed to calc refreezing at all z points
# also make sure / works for multiple arrays in virtual blue if more than one crevasse
left = np.interp(self.z,self.temperature.z,virtualblue_left/self.thermal_freq)
right = np.interp(self.z, self.temperature.z, virtualblue_right/self.thermal_freq)

# combine left and right into one
setattr(self,'',left)
setattr(self,'',right)
```
