### PR TITLE
Refreezing calculation updates and fixes

### DIFF
--- a/crevprop/iceblock.py
+++ b/crevprop/iceblock.py
@@ -364,7 +364,9 @@ class IceBlock(Ice):
     def _get_virtualblue(self):
         virtualblue_left, virtualblue_right = self.temperature.refreezing()
 
-        for num, crev in enumerate(virtualblue_left)
+        # for num, crev in enumerate(virtualblue_left):
+
+        pass
 
     def _init_geometry(self):
         """initialize ice block geometry


### PR DESCRIPTION
Refreezing calculation in ThermalModel now calculates `virtualblue` as potential refreezing rate for all `z` depths corresponding to a crevasses x location (e.g., does not stop at current crevasse depth which is `blue layer` and used as the source term in the temperature calculation). 


Next: add methods to `IceBlock` to interpolate virtualblue to ice block z-resolution and divide by thermal_freq to get accurate rate values. 